### PR TITLE
Firefox向けアドオンをRESTClientからRESTerに変更

### DIFF
--- a/doc/11.md
+++ b/doc/11.md
@@ -10,7 +10,7 @@
 
 #### Firefox
 
-[Firefox Addons](https://addons.mozilla.org/ja/firefox/addon/restclient/)からインストール。
+[Firefox Addons](https://addons.mozilla.org/ja/firefox/addon/rester/)からインストール。
 
 #### wiztools/rest-client
 


### PR DESCRIPTION
RESTClientはContent-TypeにJSONを指定するのがつらいので。（カスタムヘッダーに直接記載しなければならない）
RESTerならJSONを選択して送信可能。
<img width="1154" alt="screen shot 0028-07-16 at 14 37 50" src="https://cloud.githubusercontent.com/assets/1272114/16893014/ed4521c0-4b62-11e6-8a4f-e3408dc864a5.png">
